### PR TITLE
Visibility toggle for lab dates

### DIFF
--- a/community-overview.php
+++ b/community-overview.php
@@ -58,12 +58,13 @@ endwhile; ?>
       <span class="d-b mt-2 addon addon--small addon--catdog sm-up"></span></h2>
     <?php if( have_rows('lab_events') ): ?>
 
-    <ul class="event-teaser-list-wrapper c-page-content">
-      <?php while( have_rows('lab_events') ): the_row(); ?>
-
-          <?php get_template_part('template-parts/event', 'lab') ?>
+      <ul class="event-teaser-list-wrapper c-page-content">
+        <?php while( have_rows('lab_events') ): the_row(); ?>
+          <?php if (get_sub_field('visible') == TRUE) : ?>
+            <?php get_template_part('template-parts/event', 'lab') ?>
+          <?php endif ?>
         <?php endwhile ?>
-    </ul>
+      </ul>
     <?php endif ?>
   </div>
 </section>

--- a/page-home.php
+++ b/page-home.php
@@ -190,12 +190,15 @@ endwhile;
             <?php if ( $the_query->have_posts() ) :
               while ( $the_query->have_posts() ) : $the_query->the_post();
                 while( have_rows('lab_events') ): the_row();
-                  $info = array('lab' => $post->post_title,
-                                'img' => get_sub_field('image'),
-                               'title' => get_sub_field('title'),
-                               'date_technical' => get_sub_field('date_technical'),
-                               'date' => get_sub_field('date'));
-                  array_push($all_dates, $info);
+                  if (get_sub_field('visible') == TRUE) :
+                    $info = array('lab' => $post->post_title,
+                                 'link' => get_post_permalink(),
+                                  'img' => get_sub_field('image'),
+                                 'title' => get_sub_field('title'),
+                                 'date_technical' => get_sub_field('date_technical'),
+                                 'date' => get_sub_field('date'));
+                    array_push($all_dates, $info);
+                  endif;
                 endwhile;
               endwhile;
             wp_reset_postdata();

--- a/page-home.php
+++ b/page-home.php
@@ -131,13 +131,15 @@ endwhile;
             <?php if ( $the_query->have_posts() ) :
               while ( $the_query->have_posts() ) : $the_query->the_post();
                 while( have_rows('lab_events') ): the_row();
-                  $info = array('lab' => $post->post_title,
-                               'link' => get_post_permalink(),
-                                'img' => get_sub_field('image'),
-                               'title' => get_sub_field('title'),
-                               'date_technical' => get_sub_field('date_technical'),
-                               'date' => get_sub_field('date'));
-                  array_push($all_dates, $info);
+                  if (get_sub_field('visible') == TRUE) :
+                    $info = array('lab' => $post->post_title,
+                                 'link' => get_post_permalink(),
+                                  'img' => get_sub_field('image'),
+                                 'title' => get_sub_field('title'),
+                                 'date_technical' => get_sub_field('date_technical'),
+                                 'date' => get_sub_field('date'));
+                    array_push($all_dates, $info);
+                  endif;
                 endwhile;
               endwhile;
             wp_reset_postdata();

--- a/single-lab.php
+++ b/single-lab.php
@@ -68,9 +68,10 @@ endwhile; ?>
 
     <ul class="event-teaser-list-wrapper c-page-content">
       <?php while( have_rows('lab_events') ): the_row(); ?>
-
+        <?php if (get_sub_field('visible') == TRUE) : ?>
           <?php get_template_part('template-parts/event', 'lab') ?>
-        <?php endwhile ?>
+        <?php endif ?>
+      <?php endwhile ?>
     </ul>
     <?php endif ?>
   </div>


### PR DESCRIPTION
Only display lab dates that are "visible".

To enable in Wordpress, go to Custom Fields settings, field group "Labs", repeating Field "Termine", and add a sixth field called visible (boolean).