### PR TITLE
fix for signup button 

### DIFF
--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -48,7 +48,7 @@
 
 //      if ($city && get_field('is_active', $city[0]->ID) == true) :
 //         $event = get_field('next_event', $city[0]->ID)[0];
-        if (get_field('anmeldungslink'): ?>
+        if (get_field('anmeldungslink')) : ?>
         <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
       <?php endif; ?>
     </div>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -48,7 +48,7 @@
 
 //      if ($city && get_field('is_active', $city[0]->ID) == true) :
 //         $event = get_field('next_event', $city[0]->ID)[0];
-        if (get_field('anmeldungslink')) : ?>
+        if (! empty(get_field('anmeldungslink'))) : ?>
         <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
       <?php endif; ?>
     </div>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -37,22 +37,20 @@
       <div class="c-page-excerpt"><p><?php the_field('retro_intro'); ?></p></div>
 
       <?php
-      $loc_term = wp_get_post_terms($post->ID, 'location'); ?>
+      $loc_term = wp_get_post_terms($post->ID, 'location');
+      $city = get_posts(array(
+      'post_type' => 'page',
+      'posts_per_page' => 1,
+      'tax_query' => array(
+        lauch_fill_tax_query('location', $loc_term[0]->slug),
+      )
+      ));
 
-      <p><?php the_field('anmeldungslink'); ?></p>
-
-      <?php
-
-      $fields = get_fields();
-
-      if( $fields ): ?>
-          <ul>
-              <?php foreach( $fields as $name => $value ): ?>
-                  <li><b><?php echo $name; ?></b> <?php echo $value; ?></li>
-              <?php endforeach; ?>
-          </ul>
+      if ($city && get_field('is_active', $city[0]->ID) == true) :
+         $event = get_field('next_event', $city[0]->ID)[0];
+      ?>
+        <a href="<?php echo get_field('anmeldungslink', $event->ID) ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
       <?php endif; ?>
-
     </div>
 
     <?php if (get_field('illustration_right')) : ?>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -37,7 +37,7 @@
       <div class="c-page-excerpt"><p><?php the_field('retro_intro'); ?></p></div>
 
       <?php
-      $loc_term = wp_get_post_terms($post->ID, 'location');
+      $loc_term = wp_get_post_terms($post->ID, 'location'); ?>
 //      $city = get_posts(array(
 //      'post_type' => 'page',
 //      'posts_per_page' => 1,
@@ -48,9 +48,12 @@
 
 //      if ($city && get_field('is_active', $city[0]->ID) == true) :
 //         $event = get_field('next_event', $city[0]->ID)[0];
-        if (! empty(get_field('anmeldungslink'))) : ?>
-        <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
-      <?php endif; ?>
+
+<p><?php the_field('anmeldungslink'); ?></p>
+
+//        if (! empty(get_field('anmeldungslink'))) : ?>
+//        <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
+//      <?php endif; ?>
     </div>
 
     <?php if (get_field('illustration_right')) : ?>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -53,7 +53,7 @@
 
 //        if (! empty(get_field('anmeldungslink'))) : ?>
 //        <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
-//      <?php endif; ?>
+//      < ?php endif; ?>
     </div>
 
     <?php if (get_field('illustration_right')) : ?>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -50,7 +50,7 @@
          $event = get_field('next_event', $city[0]->ID)[0];
          if (get_field('anmeldungslink', $event->ID)):
       ?>
-        <a href="<?php themes_field('anmeldungslink', $event->ID) ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
+        <a href="<?php the_field('anmeldungslink', $event->ID) ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
       <?php endif; endif; ?>
     </div>
 

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -46,9 +46,9 @@
       )
       ));
 
-      if (get_field('anmeldungslink', $event->ID)):
+      if (get_field('anmeldungslink')):
       ?>
-        <a href="<?php echo get_field('anmeldungslink', $event->ID) ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
+        <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
       <?php endif; ?>
     </div>
 

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -38,22 +38,9 @@
 
       <?php
       $loc_term = wp_get_post_terms($post->ID, 'location'); ?>
-//      $city = get_posts(array(
-//      'post_type' => 'page',
-//      'posts_per_page' => 1,
-//      'tax_query' => array(
-//        lauch_fill_tax_query('location', $loc_term[0]->slug),
-//      )
-//      ));
 
-//      if ($city && get_field('is_active', $city[0]->ID) == true) :
-//         $event = get_field('next_event', $city[0]->ID)[0];
+      <p><?php the_field('anmeldungslink'); ?></p>
 
-<p><?php the_field('anmeldungslink'); ?></p>
-
-//        if (! empty(get_field('anmeldungslink'))) : ?>
-//        <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
-//      < ?php endif; ?>
     </div>
 
     <?php if (get_field('illustration_right')) : ?>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -48,9 +48,10 @@
 
       if ($city && get_field('is_active', $city[0]->ID) == true) :
          $event = get_field('next_event', $city[0]->ID)[0];
+         if (get_field('anmeldungslink', $event->ID)):
       ?>
-        <a href="<?php echo get_field('anmeldungslink', $event->ID) ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
-      <?php endif; ?>
+        <a href="<?php themes_field('anmeldungslink', $event->ID) ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
+      <?php endif; endif; ?>
     </div>
 
     <?php if (get_field('illustration_right')) : ?>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -41,6 +41,18 @@
 
       <p><?php the_field('anmeldungslink'); ?></p>
 
+      <?php
+
+      $fields = get_fields();
+
+      if( $fields ): ?>
+          <ul>
+              <?php foreach( $fields as $name => $value ): ?>
+                  <li><b><?php echo $name; ?></b> <?php echo $value; ?></li>
+              <?php endforeach; ?>
+          </ul>
+      <?php endif; ?>
+
     </div>
 
     <?php if (get_field('illustration_right')) : ?>

--- a/template-parts/retro-event.php
+++ b/template-parts/retro-event.php
@@ -38,16 +38,17 @@
 
       <?php
       $loc_term = wp_get_post_terms($post->ID, 'location');
-      $city = get_posts(array(
-      'post_type' => 'page',
-      'posts_per_page' => 1,
-      'tax_query' => array(
-        lauch_fill_tax_query('location', $loc_term[0]->slug),
-      )
-      ));
+//      $city = get_posts(array(
+//      'post_type' => 'page',
+//      'posts_per_page' => 1,
+//      'tax_query' => array(
+//        lauch_fill_tax_query('location', $loc_term[0]->slug),
+//      )
+//      ));
 
-      if (get_field('anmeldungslink')):
-      ?>
+//      if ($city && get_field('is_active', $city[0]->ID) == true) :
+//         $event = get_field('next_event', $city[0]->ID)[0];
+        if (get_field('anmeldungslink'): ?>
         <a href="<?php the_field('anmeldungslink') ?>" class="button event-button">Anmelden für <?php echo date('Y') ?></a>
       <?php endif; ?>
     </div>


### PR DESCRIPTION
bug: signup button still displaying on retro event when new event active but signup has ended

fix: check if signup string is empty (same as in active event)