### PR TITLE
Swap order of displayed events

### DIFF
--- a/page-home.php
+++ b/page-home.php
@@ -45,12 +45,12 @@ endwhile;
 
       <div class="c-toc c-toc--horizontal">
         <ul class="c-toc-nav">
-          <li><a href="#events" class="hover-line-trigger">
-            <span class="hover-line"><?php echo __('Events', 'lauch'); ?></span></a></li>
           <li><a href="#labs" class="hover-line-trigger">
             <span class="hover-line"><?php echo __('Labs', 'lauch'); ?></span></a></li>
           <li><a href="#community" class="hover-line-trigger">
-              <span class="hover-line"><?php echo __('Online', 'lauch'); ?></span></a></li>
+            <span class="hover-line"><?php echo __('Online', 'lauch'); ?></span></a></li>
+          <li><a href="#events" class="hover-line-trigger">
+            <span class="hover-line"><?php echo __('Events', 'lauch'); ?></span></a></li>              
         </ul>
         <div class="c-toc-content c-events-list">
           <section id="events">
@@ -233,7 +233,7 @@ endwhile;
             <?php endforeach; ?>
           </section>
 
-        </div>      
+        </div>
       </div>
     </div>
 </section>


### PR DESCRIPTION
For winter (no events) display dates from labs and online first on the home page.