### PR TITLE
Prefer media.ccc.de over YouTube

### DIFF
--- a/template-parts/video-project.php
+++ b/template-parts/video-project.php
@@ -1,7 +1,12 @@
 <div class="c-page-section jc-sb c-page-2col c-project">
   <div class="col-l fg needs-js">
+    <?php if (get_field('mediaccc')): ?>
+    <iframe width="560" height="315" src="<?php the_field('mediaccc')?>/oembed" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <noscript>Kein JavaScript? <a href="<?php the_field('mediaccc')?>">Sie dir das Video hier an!</a></noscript>
+    <?php else ?>
     <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/<?php the_field('youtubeid', $post) ?>?controls=1&rel=0" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
     <noscript>Kein JavaScript? <a href="https://youtube.com/watch?v=<?php the_field('youtubeid', $post) ?>">Sie dir das Video hier an!</a></noscript>
+    <? endif ?>
   </div>
   <div class="col-s c-project-profile">
     <dl>
@@ -34,7 +39,10 @@
           <a href="<?php the_field('github'); ?>">Git-Repository <?php echo render_svg('/images/arrow-external-white.svg'); ?></a>
         <?php endif ?>
         <?php if (get_field('mediaccc')): ?>
-          <a href="<?php the_field('mediaccc')?>">Media.CCC <?php echo render_svg('/images/arrow-external-white.svg'); ?></a>
+          <a href="<?php the_field('mediaccc')?>">Media.CCC.de <?php echo render_svg('/images/arrow-external-white.svg'); ?></a>
+        <?php endif ?>
+        <?php if (get_field('youtubeid')): ?>
+          <a href="https://youtube.com/watch?v=<?php the_field('youtubeid', $post) ?>">YouTube <?php echo render_svg('/images/arrow-external-white.svg'); ?></a>
         <?php endif ?>
         <?php if (get_field('hackdashurl')): ?>
           <a href="<?php the_field('hackdashurl')?>">HackDash <?php echo render_svg('/images/arrow-external-white.svg'); ?></a>


### PR DESCRIPTION
This MR introduces the function that the media.ccc.de embed is preferred over the YouTube embed.
As we already have a custom field ( `mediaccc` )that contains the full link to media.ccc.de this only adds the `/oembed` to the end of the URL and display's it in a iframe similar to the one that displays the YouTube content. If we at some point switch from the full URL to the ID as we do with YouTube this needs to be changed. (But as all the field inputs need to be changed as well I think we'll stick to the full URL..)
If the `mediaccc` custom field is not set, the YouTube ID will be used and the "old" iframe will be shown.

Changes in this MR: 
- If media.ccc.de link is present use it for the iframe instead of YouTube
- If no media.ccc.de link is present fallback to YouTube
- Add YouTube link to the "LINKS" Sidebar
- Renamed "Media.CCC" to "Media.CCC.de"